### PR TITLE
Handled issue when current user returns wrong data

### DIFF
--- a/src/app/service/cognito.service.ts
+++ b/src/app/service/cognito.service.ts
@@ -38,19 +38,26 @@ export class CognitoUtil {
         ClientId: CognitoUtil._CLIENT_ID
     };
 
+    private currentUser;
+    private userPool;
 
     public static getAwsCognito(): any {
         return AWSCognito
     }
 
     getUserPool() {
-        return new AWSCognito.CognitoIdentityServiceProvider.CognitoUserPool(CognitoUtil._POOL_DATA);
+        if (!this.userPool) {
+            this.userPool = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserPool(CognitoUtil._POOL_DATA);
+        }
+        return this.userPool;
     }
 
     getCurrentUser() {
-        return this.getUserPool().getCurrentUser();
+        if (!this.currentUser) {
+            this.currentUser = this.getUserPool().getCurrentUser();
+        }
+        return this.currentUser;
     }
-
 
     getCognitoIdentity(): string {
         return AWS.config.credentials.identityId;


### PR DESCRIPTION
**Issue:** `CognitoUtil::getCurrentUser();` returns wrong or unauthenticated version of current user.

**Issue Replication**
https://gist.github.com/rakeshtembhurne/5e2f02abe78588fad0f66bb3e6881d43

Above is the diff shows code working correctly. Replacing old `getUserPool()` and `getCurrentUser()` causes errors.

