### PR TITLE
FIX: replace "REGION" in aws/authrole.json

### DIFF
--- a/aws/authrole.json
+++ b/aws/authrole.json
@@ -23,7 +23,7 @@
         "dynamodb:DeleteItem"
       ],
       "Resource": [
-        "arn:aws:dynamodb:us-east-1:ACCOUNT_NUMBER:table/TABLE_NAME"
+        "arn:aws:dynamodb:REGION:ACCOUNT_NUMBER:table/TABLE_NAME"
       ],
       "Condition": {
         "ForAllValues:StringEquals": {

--- a/aws/createResources.sh
+++ b/aws/createResources.sh
@@ -47,7 +47,7 @@ aws iam put-role-policy --role-name $ROLE_NAME_PREFIX-unauthenticated-role --pol
 # Create an IAM role for authenticated users
 cat authrole-trust-policy.json | sed 's/IDENTITY_POOL/'$identityPoolId'/' > /tmp/authrole-trust-policy.json
 aws iam create-role --role-name $ROLE_NAME_PREFIX-authenticated-role --assume-role-policy-document file:///tmp/authrole-trust-policy.json
-cat authrole.json | sed 's/TABLE_NAME/'$TABLE_NAME'/' | sed 's/ACCOUNT_NUMBER/'$AWS_ACCOUNT'/' > /tmp/authrole.json
+cat authrole.json | sed 's/TABLE_NAME/'$TABLE_NAME'/' | sed 's/ACCOUNT_NUMBER/'$AWS_ACCOUNT'/' | sed 's/REGION/'$REGION'/' > /tmp/authrole.json
 aws iam put-role-policy --role-name $ROLE_NAME_PREFIX-authenticated-role --policy-name CognitoPolicy --policy-document file:///tmp/authrole.json
 
 # Create the user pool


### PR DESCRIPTION
Replace hard-coded "us-east-1" region in "aws/authrole.json" in order to prevent dynamodb auth error if deploy to another region.