### PR TITLE
Fixed duplicate app.component load during startup.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,42 +1,16 @@
 /**
  * @author Vladimir Budilov
  *
- * This is the entry-way into the routing logic. This is the first component that's called when the app
+ * This is the first component that's called when the app
  * loads.
  *
  */
-import {Component, OnInit} from "@angular/core";
-import {AwsUtil} from "./service/aws.service";
-import {UserLoginService, CognitoUtil, LoggedInCallback} from "./service/cognito.service";
+import {Component} from "@angular/core";
 
 @Component({
-    selector: 'app-root',
+    selector: 'app-component',
     templateUrl: 'template/app.html'
 })
-export class AppComponent implements OnInit, LoggedInCallback {
-
-    constructor(public awsUtil: AwsUtil, public userService: UserLoginService, public cognito: CognitoUtil) {
-        console.log("AppComponent: constructor");
-    }
-
-    ngOnInit() {
-        console.log("AppComponent: Checking if the user is already authenticated");
-        this.userService.isAuthenticated(this);
-    }
-
-    isLoggedIn(message: string, isLoggedIn: boolean) {
-        console.log("AppComponent: the user is authenticated: " + isLoggedIn);
-        let mythis = this;
-        this.cognito.getIdToken({
-            callback() {
-
-            },
-            callbackWithParam(token: any) {
-                // Include the passed-in callback here as well so that it's executed downstream
-                console.log("AppComponent: calling initAwsService in callback")
-                mythis.awsUtil.initAwsService(null, isLoggedIn, token);
-            }
-        });
-    }
+export class AppComponent {
 }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,7 +19,7 @@ import {RegisterComponent} from "./public/auth/register/registration.component";
 import {ForgotPasswordStep1Component, ForgotPassword2Component} from "./public/auth/forgot/forgotPassword.component";
 import {LogoutComponent, RegistrationConfirmationComponent} from "./public/auth/confirm/confirmRegistration.component";
 import {ResendCodeComponent} from "./public/auth/resend/resendCode.component";
-
+import {RootComponent} from "./root/root.component";
 
 @NgModule({
     declarations: [
@@ -37,6 +37,7 @@ import {ResendCodeComponent} from "./public/auth/resend/resendCode.component";
         MyProfileComponent,
         SecureHomeComponent,
         JwtComponent,
+        RootComponent,
         AppComponent
     ],
     imports: [

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,12 +5,12 @@ import {SecureHomeComponent} from "./secure/landing/securehome.component";
 import {MyProfileComponent} from "./secure/profile/myprofile.component";
 import {JwtComponent} from "./secure/jwttokens/jwt.component";
 import {UseractivityComponent} from "./secure/useractivity/useractivity.component";
-import {AppComponent} from "./app.component";
 import {LoginComponent} from "./public/auth/login/login.component";
 import {RegisterComponent} from "./public/auth/register/registration.component";
 import {ForgotPassword2Component, ForgotPasswordStep1Component} from "./public/auth/forgot/forgotPassword.component";
 import {RegistrationConfirmationComponent, LogoutComponent} from "./public/auth/confirm/confirmRegistration.component";
 import {ResendCodeComponent} from "./public/auth/resend/resendCode.component";
+import {RootComponent} from "./root/root.component";
 
 const homeRoutes: Routes = [
     {
@@ -54,7 +54,7 @@ const secureHomeRoutes: Routes = [
 const routes: Routes = [
     {
         path: '',
-        component: AppComponent,
+        component: RootComponent,
         children: [
             ...homeRoutes,
             ...secureHomeRoutes,

--- a/src/app/root/root.component.ts
+++ b/src/app/root/root.component.ts
@@ -1,0 +1,41 @@
+/**
+ * @author Vladimir Budilov
+ *
+ * This is the entry-way into the routing logic. 
+ *
+ */
+import {Component, OnInit} from "@angular/core";
+import {AwsUtil} from "../service/aws.service";
+import {UserLoginService, CognitoUtil, LoggedInCallback} from "../service/cognito.service";
+
+@Component({
+    selector: 'root-component',
+    templateUrl: 'root.html'
+})
+export class RootComponent implements OnInit, LoggedInCallback {
+
+    constructor(public awsUtil: AwsUtil, public userService: UserLoginService, public cognito: CognitoUtil) {
+        console.log("RootComponent: constructor");
+    }
+
+    ngOnInit() {
+        console.log("RootComponent: Checking if the user is already authenticated");
+        this.userService.isAuthenticated(this);
+    }
+
+    isLoggedIn(message: string, isLoggedIn: boolean) {
+        console.log("RootComponent: the user is authenticated: " + isLoggedIn);
+        let mythis = this;
+        this.cognito.getIdToken({
+            callback() {
+
+            },
+            callbackWithParam(token: any) {
+                // Include the passed-in callback here as well so that it's executed downstream
+                console.log("RootComponent: calling initAwsService in callback")
+                mythis.awsUtil.initAwsService(null, isLoggedIn, token);
+            }
+        });
+    }
+}
+

--- a/src/app/root/root.html
+++ b/src/app/root/root.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/src/index.html
+++ b/src/index.html
@@ -40,6 +40,6 @@
 <script src="assets/ui-js/sb-admin-2.min.js"></script>
 <!-- /Metis Menu Plugin JavaScript -->
 
-<app-root>Loading...</app-root>
+<app-component>Loading...</app-component>
 </body>
 </html>


### PR DESCRIPTION
Looking at the console logs, I'm seeing that when the initial page loads, the AppComponent constructor and ngOnInit method are both being called twice (this is from [http://cognito.budilov.com/home):](http://cognito.budilov.com/home)

![image](https://cloud.githubusercontent.com/assets/702031/22632212/f17d344c-ebdc-11e6-9c54-3f023270586c.png)

The problem seems to be that the app.component is defined as the root route in your app.routes.ts.  So the application is loading the AppCompnonent twice (once from index.html and again for the routing definition).  This is confirmed in Augery:

![image](https://cloud.githubusercontent.com/assets/702031/22632331/f0f31388-ebdd-11e6-8c27-80bdc3c3b81f.png)

The solutions (as described in this SO post -- [http://stackoverflow.com/questions/38378022/why-my-angular2-app-inicialize-twice](http://stackoverflow.com/questions/38378022/why-my-angular2-app-inicialize-twice)) is to reference the AppComponent in the index.html but NOT reference the AppComponent in the routing configuration.  Instead, a new RootComponent is created for the routing configuration.  

So I created a new component called RootComponent and moved most of the AppComponent's logic into it.  Then I referred to the RootComponent in the app.routes.ts file.

By doing this, the Augery and logs look like this:

![image](https://cloud.githubusercontent.com/assets/702031/22632447/fb825754-ebde-11e6-8ef6-a890c5f18ad0.png)

![image](https://cloud.githubusercontent.com/assets/702031/22632461/22dc5de0-ebdf-11e6-88b1-220fc22bfc95.png)


Please let me know if you have any questions.