### PR TITLE
Add warning for json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ while Elastic Beanstalk gives you the capability of adding backend operations to
 * [What is Elastic Beanstalk](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/Welcome.html)
 * [What is S3](http://docs.aws.amazon.com/AmazonS3/latest/dev/Welcome.html)
 
+** createResources.sh requires your [aws cli to be configured](http://docs.aws.amazon.com/cli/latest/userguide/controlling-output.html) for JSON output.  **
+
 ```
 # Install the AWS resources and deploy your application to either Elastic Beanstalk or S3
 cd aws


### PR DESCRIPTION
Not sure why I got switched to text output, but many things break in createResources.sh if not set for json, so I figured mentioning it in the docs was the easiest fix.