### PR TITLE
Updated angular cli to 1.0.0 and others

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "express": "~4.13.4",
     "morgan": "~1.7.0",
     "serve-favicon": "~2.3.0",
-    "codelyzer": "~0.0.26",
+    "codelyzer": "2.0.1",
     "karma": "1.2.0",
     "karma-chrome-launcher": "2.0.0",
     "karma-cli": "1.0.1",
     "karma-jasmine": "1.0.2",
-    "karma-remap-istanbul": "0.2.1",
+    "karma-remap-istanbul": "0.6.0",
     "webpack": "2.2.1",
     "webpack-dev-middleware": "1.10.1",
     "webpack-dev-server": "2.4.2",
@@ -50,7 +50,7 @@
 
   },
   "devDependencies": {
-    "@angular/cli": "1.0.0-rc.4",
+    "@angular/cli": "1.0.0",
     "@angular/compiler-cli": "4.0.0",
     "protractor": "5.1.1",
     "ts-node": "2.1.0",


### PR DESCRIPTION
Updated angular/cli to v1 release and update codelyzer and karma-remap-istanbul to remove old version warnings during npm install.  

This package.json gives me a clean install with no warnings when following the documentation.