### PR TITLE
FIX: get credentials right after user logged in

### DIFF
--- a/src/app/service/cognito.service.ts
+++ b/src/app/service/cognito.service.ts
@@ -247,7 +247,14 @@ export class UserLoginService {
 
                 console.log("UserLoginService: set the AWS credentials - " + JSON.stringify(AWS.config.credentials));
                 console.log("UserLoginService: set the AWSCognito credentials - " + JSON.stringify(AWSCognito.config.credentials));
-                callback.cognitoCallback(null, result);
+                AWS.config.credentials.get(function (err) {
+                    if (!err) {
+                        callback.cognitoCallback(null, result);
+                    } else {
+                        callback.cognitoCallback(err.message, null);
+                    }
+                });
+
             },
             onFailure: function (err) {
                 callback.cognitoCallback(err.message, null);


### PR DESCRIPTION
Without calling "get" method, identity data (e.g. cognito ID) cannot be retrieved right after user logs in.

How to replicate the issue?
- Clean all local storage data related to cognito
- Logout (if logged in)
- Login
- Check "My Profile Parameters" and cognito ID shows nothing there