### PR TITLE
Enable custom service endpoints for sample application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /node_modules
 /src/bower_components
 /public/bower_components
+package-lock.json
 
 # IDEs and editors
 /.idea

--- a/README.md
+++ b/README.md
@@ -89,4 +89,18 @@ eb deploy
 eb open
 ```
 
+## Local Testing
 
+This section contains instructions on how to test the application locally (using mocked services instead of the real AWS services).
+
+### LocalStack
+
+To test this application using [LocalStack](https://github.com/localstack/localstack), you can use the `awslocal` CLI (https://github.com/localstack/awscli-local).
+```
+pip install awscli-local
+```
+Simply parameterize the `./createResources.sh` installation script with `aws_cmd=awslocal`:
+```
+cd aws; aws_cmd=awslocal ./createResources.sh
+```
+Once the code is deployed to the local S3 server, the application is accessible via http://localhost:4572/cognitosample-localapp/index.html (Assuming "localapp" has been chosen as resource name in the previous step)

--- a/src/app/service/ddb.service.ts
+++ b/src/app/service/ddb.service.ts
@@ -31,7 +31,11 @@ export class DynamoDBService {
             }
         };
 
-        var docClient = new DynamoDB.DocumentClient();
+        var clientParams:any = {};
+        if (environment.dynamodb_endpoint) {
+            clientParams.endpoint = environment.dynamodb_endpoint;
+        }
+        var docClient = new DynamoDB.DocumentClient(clientParams);
         docClient.query(params, onQuery);
 
         function onQuery(err, data) {
@@ -60,9 +64,14 @@ export class DynamoDBService {
 
     write(data: string, date: string, type: string): void {
         console.log("DynamoDBService: writing " + type + " entry");
-        var DDB = new DynamoDB({
+
+        let clientParams:any = {
             params: {TableName: environment.ddbTableName}
-        });
+        };
+        if (environment.dynamodb_endpoint) {
+            clientParams.endpoint = environment.dynamodb_endpoint;
+        }
+        var DDB = new DynamoDB(clientParams);
 
         // Write the item to the table
         var itemParams =

--- a/src/app/service/s3.service.ts
+++ b/src/app/service/s3.service.ts
@@ -19,11 +19,15 @@ export class S3Service {
             region: environment.bucketRegion,
         });
 
-        var s3 = new S3({
+        let clientParams:any = {
             region: environment.bucketRegion,
             apiVersion: '2006-03-01',
             params: {Bucket: environment.rekognitionBucket}
-        });
+        };
+        if (environment.s3_endpoint) {
+            clientParams.endpoint = environment.s3_endpoint;
+        }
+        var s3 = new S3(clientParams);
 
         return s3
     }

--- a/src/app/service/user-login.service.ts
+++ b/src/app/service/user-login.service.ts
@@ -1,3 +1,4 @@
+import {environment} from "../../environments/environment";
 import {Injectable} from "@angular/core";
 import {DynamoDBService} from "./ddb.service";
 import {CognitoCallback, CognitoUtil, LoggedInCallback} from "./cognito.service";
@@ -48,7 +49,11 @@ export class UserLoginService {
                 // If the first SDK call we make wants to use our IdentityID, we have a
                 // chicken and egg problem on our hands. We resolve this problem by "priming" the AWS SDK by calling a
                 // very innocuous API call that forces this behavior.
-                let sts = new STS();
+                let clientParams:any = {};
+                if (environment.sts_endpoint) {
+                    clientParams.endpoint = environment.sts_endpoint;
+                }
+                let sts = new STS(clientParams);
                 sts.getCallerIdentity(function (err, data) {
                     console.log("UserLoginService: Successfully set the AWS credentials");
                     callback.cognitoCallback(null, result);


### PR DESCRIPTION
This PR enables configuration of custom service endpoints.

Specifying custom endpoints in the AWS SDK is an extremely useful feature for testing. The main motivation for this change is to make the sample application work with [LocalStack](https://github.com/localstack/localstack) (a local AWS testing/mocking service).

In particular, this change enables:
1) using a custom CLI command (`awslocal` instead of `aws`)
2) using local service endpoints instead of the AWS production endpoints

The application can be initialized using the `awslocal` CLI (https://github.com/localstack/awscli-local) to use the local service endpoints:
```
$ pip install awscli-local
$ cd aws; aws_cmd=awslocal ./createResources.sh
```

Note that this is a non-breaking change that fully maintains backwards compatibility. The `$aws_cmd` variable defaults to `aws`, and by default the application still uses the production AWS services.