### PR TITLE
Enable custom service endpoints for sample application (v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /node_modules
 /src/bower_components
 /public/bower_components
+package-lock.json
 
 # IDEs and editors
 /.idea

--- a/README.md
+++ b/README.md
@@ -94,4 +94,18 @@ eb deploy
 eb open
 ```
 
+## Local Testing
 
+This section contains instructions on how to test the application locally (using mocked services instead of the real AWS services).
+
+### LocalStack
+
+To test this application using [LocalStack](https://github.com/localstack/localstack), you can use the `awslocal` CLI (https://github.com/localstack/awscli-local).
+```
+pip install awscli-local
+```
+Simply parameterize the `./createResources.sh` installation script with `aws_cmd=awslocal`:
+```
+cd aws; aws_cmd=awslocal ./createResources.sh
+```
+Once the code is deployed to the local S3 server, the application is accessible via http://localhost:4572/cognitosample-localapp/index.html (Assuming "localapp" has been chosen as resource name in the previous step)

--- a/src/app/service/ddb.service.ts
+++ b/src/app/service/ddb.service.ts
@@ -31,7 +31,11 @@ export class DynamoDBService {
             }
         };
 
-        var docClient = new DynamoDB.DocumentClient();
+        var clientParams:any = {};
+        if (environment.dynamodb_endpoint) {
+            clientParams.endpoint = environment.dynamodb_endpoint;
+        }
+        var docClient = new DynamoDB.DocumentClient(clientParams);
         docClient.query(params, onQuery);
 
         function onQuery(err, data) {
@@ -60,9 +64,14 @@ export class DynamoDBService {
 
     write(data: string, date: string, type: string): void {
         console.log("DynamoDBService: writing " + type + " entry");
-        var DDB = new DynamoDB({
+
+        let clientParams:any = {
             params: {TableName: environment.ddbTableName}
-        });
+        };
+        if (environment.dynamodb_endpoint) {
+            clientParams.endpoint = environment.dynamodb_endpoint;
+        }
+        var DDB = new DynamoDB(clientParams);
 
         // Write the item to the table
         var itemParams =

--- a/src/app/service/s3.service.ts
+++ b/src/app/service/s3.service.ts
@@ -19,11 +19,15 @@ export class S3Service {
             region: environment.bucketRegion,
         });
 
-        var s3 = new S3({
+        let clientParams:any = {
             region: environment.bucketRegion,
             apiVersion: '2006-03-01',
             params: {Bucket: environment.rekognitionBucket}
-        });
+        };
+        if (environment.s3_endpoint) {
+            clientParams.endpoint = environment.s3_endpoint;
+        }
+        var s3 = new S3(clientParams);
 
         return s3
     }

--- a/src/app/service/user-login.service.ts
+++ b/src/app/service/user-login.service.ts
@@ -1,3 +1,4 @@
+import {environment} from "../../environments/environment";
 import {Injectable} from "@angular/core";
 import {DynamoDBService} from "./ddb.service";
 import {CognitoCallback, CognitoUtil, LoggedInCallback} from "./cognito.service";
@@ -48,7 +49,11 @@ export class UserLoginService {
                 // If the first SDK call we make wants to use our IdentityID, we have a
                 // chicken and egg problem on our hands. We resolve this problem by "priming" the AWS SDK by calling a
                 // very innocuous API call that forces this behavior.
-                let sts = new STS();
+                let clientParams:any = {};
+                if (environment.sts_endpoint) {
+                    clientParams.endpoint = environment.sts_endpoint;
+                }
+                let sts = new STS(clientParams);
                 sts.getCallerIdentity(function (err, data) {
                     console.log("UserLoginService: Successfully set the AWS credentials");
                     callback.cognitoCallback(null, result);

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -11,6 +11,13 @@ export const environment = {
     albumName: "usercontent",
     bucketRegion: 'us-east-1',
 
-    ddbTableName: 'LoginTrail'
+    ddbTableName: 'LoginTrail',
+
+    cognito_idp_endpoint: '',
+    cognito_identity_endpoint: '',
+    sts_endpoint: '',
+    dynamodb_endpoint: '',
+    s3_endpoint: ''
+
 };
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -11,6 +11,13 @@ export const environment = {
     albumName: "usercontent",
     bucketRegion: 'us-east-1',
 
-    ddbTableName: 'LoginTrail'
+    ddbTableName: 'LoginTrail',
+
+    cognito_idp_endpoint: '',
+    cognito_identity_endpoint: '',
+    sts_endpoint: '',
+    dynamodb_endpoint: '',
+    s3_endpoint: ''
+
 };
 


### PR DESCRIPTION
@vbudilov Apologies for the issue with the last PR (#87), that was an oversight. I did test the change manually, but always following the route of running `createResources.sh` (which generates the environment files).

In this updated PR I've added the default configurations to the environment files and made sure that compiling and running via `npm start` actually works. Sorry again for any inconvenience. Thanks