### PR TITLE
Fixing build so that when EB is chosen, packages.json gets executed

### DIFF
--- a/aws/createResources.sh
+++ b/aws/createResources.sh
@@ -108,6 +108,7 @@ createEBResources() {
 
     # Commit changes made
     cd $ROOT_DIR
+    npm run-script build
 
     # Create Elastic Beanstalk application
     eb init $ROOT_NAME --region $REGION --platform $EB_PLATFORM

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "ng test",
     "pree2e": "webdriver-manager update",
     "e2e": "protractor",
-    "build": "ng build --prod --aot=false"
+    "build": "npm install && ng build --prod --aot=false"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Two changes:
1. Update to packages.json with the correct build steps
2. Modify the createResources.sh script so that npm run-script build processes packages.json and correctly builds the application.