### PR TITLE
binding to 0.0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "description": "A single-page web app, based on angular4, utilizing Amazon Cognito, S3, and DynamoDB (serverless architecture)",
   "angular-cli": {},
   "scripts": {
-    "start": "ng serve --port 3333",
+    "start": "ng serve --port 3333 --host=0.0.0.0",
     "startnode": "node ./bin/www",
     "lint": "tslint \"src/**/*.ts\"",
     "test": "ng test",


### PR DESCRIPTION
I would ask to add a binding to 0.0.0.0. This would make it easier to execute this application in VMs, containers.
Without that parameter - the applicaiton would bind to a private network interface and only respond to "localhost", but not to queries to the public ip of the container or vagrant VM.